### PR TITLE
Added support to iterables in Be.empty

### DIFF
--- a/expects/expectations.py
+++ b/expects/expectations.py
@@ -86,7 +86,16 @@ class Be(Expectation):
 
     @property
     def empty(self):
-        self._assert(len(self.actual) == 0, self.error_message('empty'))
+        self._assert(self.__is_empty(self.actual), self.error_message('empty'))
+
+    def __is_empty(self, collection):
+        try:
+            return len(collection) == 0
+        except TypeError:
+            try:
+                next(collection)
+            except StopIteration:
+                return True
 
     def error_message(self, tail):
         return self._parent.error_message('be {}'.format(tail))

--- a/spec/expect_spec.py
+++ b/spec/expect_spec.py
@@ -183,8 +183,17 @@ with describe(expect) as _:
                 def it_should_pass_if_actual_is_empty():
                     expect('').to.be.empty
 
+                def it_should_pass_if_actual_is_an_empty_iterable():
+                    expect(iter('')).to.be.empty
+
                 def it_should_fail_if_actual_is_not_empty():
                     actual = 'foo'
+
+                    with failure(actual, 'to be empty'):
+                        expect(actual).to.be.empty
+
+                def it_should_fail_if_actual_is_a_non_empty_iterable():
+                    actual = iter('foo')
 
                     with failure(actual, 'to be empty'):
                         expect(actual).to.be.empty


### PR DESCRIPTION
As an increasingly number of methods now return either iterators or view objects, it would be rather nice to be able to test them.

A very simple though inefficient way of testing emptiness on a generator is just consume it into a list:

``` python
expect(list(generator())).to.be.empty
```

This certainly is a limited method, as it may trigger some unwanted effects due to the iteration over unknown in size, very large or even infinite collections.

The present approach just wastes the first element on the worst case, just by trying to iterate the generator right away, in a EAFP fashion. 

``` python
try:
    next(generator())
except StopIteration:
    return True
```

Any python2-3 implementation should respond to calling next on a generator by either handing over the next element or raising a StopIteration exception, allowing us to know the generator empty on the latter.

This sadly disposes the first element, which cannot be held or returned for further testing.

A "peek" function might be implemented, which saved the first extracted element and returned a composed generator which chained together the first value and the rest, thus simulating the whole collection. IMO this might result overly complicated and rather unecessary at this point.

``` python
try:
    element = next(generator)
except StopIteration:
    return True
else:
    return itertools.chain([element], generator)
```
