### PR TITLE
Adds support for iterables in have.length

### DIFF
--- a/expects/expectations.py
+++ b/expects/expectations.py
@@ -166,10 +166,16 @@ class Have(Expectation):
                 expectation(name, value)
 
     def length(self, expected):
-        value = len(self.actual)
+        value = self.__length(self.actual)
 
         self._assert(value == expected, self.error_message(
             'length {} but was {}'.format(expected, value)))
+
+    def __length(self, collection):
+        try:
+            return len(collection)
+        except TypeError:
+            return sum(1 for i in collection)
 
     def error_message(self, tail):
         return self._parent.error_message('have {}'.format(tail))

--- a/spec/expect_spec.py
+++ b/spec/expect_spec.py
@@ -339,6 +339,16 @@ with describe(expect) as _:
                     with failure(actual, 'to have length 2 but was 3'):
                         expect(actual).to.have.length(2)
 
+                def it_should_pass_if_actual_iterable_has_the_expected_length():
+                    expect(iter('foo')).to.have.length(3)
+
+                def it_should_fail_if_actual_iterable_does_not_have_the_expected_length():
+                    actual = iter('foo')
+
+                    with failure(actual, 'to have length 2 but was 3'):
+                        expect(actual).to.have.length(2)
+
+
     with describe('not_to'):
         with describe('equal'):
             def it_should_pass_if_actual_does_not_equal_expected():


### PR DESCRIPTION
Attempts to use the len method and then falls back to enumerate each element by consuming the whole collection one at the time.

The whole collection is consumed in the operation so the iterable becomes inusable after checking it.
Really long iterables won't consume extra memory, as it is visited one item at the time.
Beware of checking length on infinite iterables, which will punish the user severely for trying to reach valhalla.
