### PR TITLE
Adds support for iterables in have

### DIFF
--- a/expects/expectations.py
+++ b/expects/expectations.py
@@ -103,8 +103,9 @@ class Be(Expectation):
 
 class Have(Expectation):
     def __call__(self, *args):
+        collection = self.actual if len(args) == 1 else set(self.actual)
         for arg in args:
-            self._assert(arg in self.actual, self.error_message(repr(arg)))
+            self._assert(arg in collection, self.error_message(repr(arg)))
 
     def property(self, *args):
         def error_message(tail):

--- a/spec/expect_spec.py
+++ b/spec/expect_spec.py
@@ -209,6 +209,17 @@ with describe(expect) as _:
                 with failure(_.lst, "to have 'foo'"):
                     expect(_.lst).to.have('bar', 'foo')
 
+            def it_should_pass_if_actual_iterable_has_expected_item():
+                expect(iter(_.lst)).to.have('bar')
+
+            def it_should_pass_if_actual_iterable_has_expected_items():
+                expect(iter(_.lst)).to.have('bar', 'baz')
+
+            def it_should_fail_if_actual_iterable_does_not_have_expected_item():
+                iterable = iter(_.lst)
+                with failure(iterable, "to have 'foo'"):
+                    expect(iterable).to.have('bar', 'foo')
+
             with describe('property'):
                 def it_should_pass_if_actual_has_property():
                     expect(_.obj).to.have.property('bar')


### PR DESCRIPTION
Even though the 'in' operator supports checking whether some item is contained within a generator, this becomes quite unreliable for multiple item checking.

The problem consist in the generator being consumed on every check, turning the whole operation order-dependent:

``` python
>>> iterable = iter(['foo', 'bar'])
>>> 'bar' in iterable
True
>>> 'foo' in iterable
False
```

The operator walks the iterable for a match, disposing non-matching elements.

``` python
>>> iterable = iter(['foo', 'bar'])
>>> 'bar' in iterable
True
>>> list(iterable)
[]
```

Such convenient default behaviour has been maintained for the special case of checking one single element.

When more than one item are tested, the iterable is consumed into a set, which is subsequently checked multiple times.

Alternatives were to copy the generator on each checking:

``` python
for arg in args:
    assert(arg in copy(generator))
```

This might be regarded as cleaner, but it is rather unefficient approach as the generator has to be walked every time, bringing in `O(n * args)`.

What was actually done is to construct a set, which is `O(n)` and then check against it, which is `O(1)`.

The iterable becomes inusable after being checked.
Very large iterables would be loaded on memory (although avoiding repeated items).
Infinite iterables would bite the user. 
Checking on infinite iterables could be achieved by using the `copy` approach, as it does not tries to consume it completely before. Hummm.
