### PR TITLE
Adds tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27,py33,pypy
+
+[testenv]
+setenv = 
+	PYTHONPATH = {toxinidir}
+
+deps =  
+	-r{toxinidir}/requirements-devel.txt
+
+commands = 
+	mamba


### PR DESCRIPTION
Local testing is lacking the same environment support as in Travis.
This translates the current `.travis.yml` into a `tox.ini` configuration.

The user can just run `tox` and test building, packaging and several interpreters with one stroke.

The `setup.py sdist` step has been omitted as it is part of the tox default behaviour.
