### PR TITLE
Add doc and specs to sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include *requirements.txt
 include README.rst
 include LICENSE
+recursive-include docs *
+recursive-include specs *.py


### PR DESCRIPTION
When packaging it's convenient to have the documentation and tests
available in the source build not only for the cases where users want
them but to verify the installation thruogh package management.
