### PR TITLE
Use Iterable instead of Iterator

### DIFF
--- a/expects/matchers/built_in/contain.py
+++ b/expects/matchers/built_in/contain.py
@@ -15,7 +15,7 @@ class contain(Matcher):
     def _normalize_sequence(method):
         @functools.wraps(method)
         def wrapper(self, subject):
-            if isinstance(subject, collections.Iterator):
+            if isinstance(subject, collections.Iterable):
                 subject = list(subject)
 
             return method(self, subject)


### PR DESCRIPTION
The difference of Iterator and Iterable[1] is than Iterator implements
all iterable and `next()` function and represents a stream of data,
but in the test context maybe the check should be with Iteable, because
set() isn't an instance of Iterator but is an instance of Iterable.

[1] https://docs.python.org/2/glossary.html#term-iterable