### PR TITLE
allow matching tolerance for equal

### DIFF
--- a/expects/matchers/built_in/equal.py
+++ b/expects/matchers/built_in/equal.py
@@ -12,3 +12,19 @@ class equal(Matcher):
 
     def _match_negated(self, subject):
         return subject != self._expected, []
+
+    def within(self, tolerance):
+        return equal_within(self._expected, tolerance)
+
+
+class equal_within(Matcher):
+    def __init__(self, expected, tolerance):
+        self._expected = expected
+        self._tolerance = tolerance
+
+    def _match(self, subject):
+        difference = abs(self._expected - subject)
+        return difference < self._tolerance, []
+
+    def __repr__(self):
+        return 'equal {0} ± {1}'.format(self._expected, self._tolerance)

--- a/specs/matchers/built_in/equal_spec.py
+++ b/specs/matchers/built_in/equal_spec.py
@@ -46,3 +46,14 @@ with describe('equal'):
         with it('should fail if object equals expected'):
             with failure('Foo with bar=crazy not to equal Foo with bar=crazy'):
                 expect(self.object_with_crazy_logic).not_to(equal(self.object_with_crazy_logic))
+
+    with context('when comparing within'):
+        with it('should pass if numbers exactly equal'):
+            expect(42).to(equal(42).within(0.1))
+
+        with it('should pass if numbers are within tolerance'):
+            expect(42.04).to(equal(42).within(0.1))
+
+        with it('should fail if numbers are not within tolerance'):
+            with failure('expected: 41 to equal 40 ± 0.5'):
+                expect(41).to(equal(40).within(0.5))


### PR DESCRIPTION
Allow matching tolerance for equal matcher. Let me know what you think.

Had considered also adding either matching to decimal places, significant figures or percent - kept it simple for the time being but happy to implement any of those if you'd accept them.
