### PR TITLE
Add the ability to pass parameters to function expect

### DIFF
--- a/expects/expectations.py
+++ b/expects/expectations.py
@@ -2,8 +2,10 @@
 
 
 class Expectation(object):
-    def __init__(self, subject):
+    def __init__(self, subject, *args, **kwargs):
         self._subject = subject
+        self._args = args
+        self._kwargs = kwargs
         self._negated = False
 
     @property
@@ -28,7 +30,7 @@ class Expectation(object):
         return getattr(
             matcher,
             '_match_negated' if self._negated else '_match'
-        )(self._subject)
+        )(self._subject, *self._args, **self._kwargs)
 
     def _failure_message(self, matcher, *args):
         return getattr(

--- a/expects/factory.py
+++ b/expects/factory.py
@@ -3,5 +3,5 @@
 from .expectations import Expectation
 
 
-def expect(subject):
-    return Expectation(subject)
+def expect(subject, *args, **kwargs):
+    return Expectation(subject, *args, **kwargs)

--- a/expects/matchers/__init__.py
+++ b/expects/matchers/__init__.py
@@ -75,7 +75,7 @@ class Matcher(object):
 
         raise NotImplementedError()
 
-    def _match_negated(self, subject):
+    def _match_negated(self, subject, *args, **kwargs):
         """Like :func:`_match` but will be called when used in a
         negated expectation. It can be used to implement a custom
         logic for negated expectations.
@@ -87,7 +87,7 @@ class Matcher(object):
 
         """
 
-        result, reason = self._match(subject)
+        result, reason = self._match(subject, *args, **kwargs)
         return not result, reason
 
     def _failure_message(self, subject, reasons):

--- a/expects/matchers/built_in/raise_error.py
+++ b/expects/matchers/built_in/raise_error.py
@@ -13,9 +13,9 @@ class _raise_error(Matcher):
     def __call__(self, *args, **kwargs):
         return _raise_error(*args, **kwargs)
 
-    def _match(self, subject):
+    def _match(self, subject, *args, **kwargs):
         try:
-            subject()
+            subject(*args, **kwargs)
         except self._expected as exc:
             if len(self._args) != 0:
                 actual_value = exc.args[0]

--- a/specs/matchers/built_in/raise_error_spec.py
+++ b/specs/matchers/built_in/raise_error_spec.py
@@ -74,6 +74,13 @@ with describe('raise_error'):
         with failure("but: AttributeError raised with 'foo'"):
             expect(callback).to(raise_error(AttributeError, 1))
 
+    with it('allows parameters to be passed to function expectation'):
+        def callback(a, b):
+            if a == b:
+                raise AttributeError()
+
+        expect(callback, 1, 1).to(raise_error(AttributeError))
+
     with context('when negated'):
         with it('passes if callable does not raise expected exception'):
             def callback():
@@ -103,6 +110,13 @@ with describe('raise_error'):
 
             with failure("but: AttributeError raised with 'foo'"):
                 expect(callback).not_to(raise_error(AttributeError, 'foo'))
+
+        with it('allows parameters to be passed to function expectation'):
+            def callback(a, b):
+                if a == b:
+                    raise AttributeError()
+
+            expect(callback, 1, 2).not_to(raise_error(AttributeError))
 
     with context('when combined'):
         with it('passes if callable raises exception and message matches'):


### PR DESCRIPTION
When we are expecting a function call to raise an exception, add the ability to call the function with arguments