### PR TITLE
Fixing ABC deprecation warning

### DIFF
--- a/expects/matchers/built_in/contain.py
+++ b/expects/matchers/built_in/contain.py
@@ -10,9 +10,9 @@ from ... import _compat
 
 class contain(Matcher):
     _NON_NORMALIZED_SEQUENCE_TYPES = (
-        collections.Iterator,
-        collections.MappingView,
-        collections.Set
+        collections.abc.Iterator,
+        collections.abc.MappingView,
+        collections.abc.Set
     )
 
     def __init__(self, *expected):

--- a/expects/matchers/built_in/contain.py
+++ b/expects/matchers/built_in/contain.py
@@ -2,6 +2,7 @@
 
 import functools
 import collections
+import sys
 
 from .. import Matcher, default_matcher
 from ...texts import plain_enumerate
@@ -9,11 +10,18 @@ from ... import _compat
 
 
 class contain(Matcher):
-    _NON_NORMALIZED_SEQUENCE_TYPES = (
-        collections.abc.Iterator,
-        collections.abc.MappingView,
-        collections.abc.Set
-    )
+    if sys.version_info >= (3, 4):
+        _NON_NORMALIZED_SEQUENCE_TYPES = (
+            collections.abc.Iterator,
+            collections.abc.MappingView,
+            collections.abc.Set
+        )
+    else:
+        _NON_NORMALIZED_SEQUENCE_TYPES = (
+            collections.Iterator,
+            collections.MappingView,
+            collections.Set
+        )
 
     def __init__(self, *expected):
         self._expected = expected


### PR DESCRIPTION
Fixing deprecation warnings...

```
/Users/jbramley/.local/share/virtualenvs/dozen-9Q1Iy_a5/lib/python3.7/site-packages/expects/matchers/built_in/contain.py:13: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  collections.Iterator,

/Users/jbramley/.local/share/virtualenvs/dozen-9Q1Iy_a5/lib/python3.7/site-packages/expects/matchers/built_in/contain.py:14: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  collections.MappingView,

/Users/blah/.local/share/virtualenvs/dozen-9Q1Iy_a5/lib/python3.7/site-packages/expects/matchers/built_in/contain.py:15: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  collections.Set
```