### PR TITLE
Add equal_values matcher for comparing object attributes

### DIFF
--- a/expects/matchers/built_in/__init__.py
+++ b/expects/matchers/built_in/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*
 
 from .equal import equal
+from .equal_values import equal_values
 from .be import be
 from .be_true import be_true
 from .be_false import be_false
@@ -24,6 +25,7 @@ from .not_ import not_
 
 __all__ = [
     'equal',
+    'equal_values',
     'be',
     'be_true',
     'be_false',

--- a/expects/matchers/built_in/equal_values.py
+++ b/expects/matchers/built_in/equal_values.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*
+
+from .. import Matcher
+
+
+class equal_values(Matcher):
+    def __init__(self, expected):
+        self._expected = expected
+
+    def _match(self, subject):
+        return subject.__dict__ == self._expected.__dict__, []
+
+    def _match_negated(self, subject):
+        return subject.__dict__ != self._expected.__dict__, []

--- a/specs/matchers/built_in/equal_values_spec.py
+++ b/specs/matchers/built_in/equal_values_spec.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*
+
+from expects import *
+from expects.testing import failure
+
+
+with describe('equal values'):
+    with context('when comparing objects'):
+        with before.each:
+            class Foo(object):
+                def __init__(self, bar):
+                    self.bar = bar
+
+            self.object = Foo(1)
+            self.another_object = Foo(1)
+            self.object_with_crazy_logic = Foo('crazy')
+
+        with it('should pass if object values does not equal expected object values'):
+            expect(self.object).not_to(equal_values(self.object_with_crazy_logic))
+
+        with it('should pass if object equals expected'):
+            expect(self.object).to(equal_values(self.another_object))

--- a/specs/matchers/built_in/equal_values_spec.py
+++ b/specs/matchers/built_in/equal_values_spec.py
@@ -18,5 +18,5 @@ with describe('equal values'):
         with it('should pass if object values does not equal expected object values'):
             expect(self.object).not_to(equal_values(self.object_with_crazy_logic))
 
-        with it('should pass if object equals expected'):
+        with it('should pass if object values equals expected object values'):
             expect(self.object).to(equal_values(self.another_object))


### PR DESCRIPTION
I was missing a matcher to compare from different object attribute values, and not having to add ```__eq__``` methods on the object itself. 

Any comment or feeback is welcome